### PR TITLE
feat: Storing auditing info in db

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -19,6 +19,21 @@ provider "registry.terraform.io/hashicorp/aws" {
     "h1:t4+ZVZIg8DbyFTMy4sZcvb7FULMG3mpg9Woh/2IaQ+o=",
     "h1:uOU0wjx6dEbtQGvtxrUu1LbAYoKukjHbrmN47tlHJ1U=",
     "h1:xo9YIxQ+0DWlHnxgHIhzdDMLFS70qDWUDRIO945qRRs=",
+    "zh:08f5e3c5256a4fbd5c988863d10e5279172b2470fec6d4fb13c372663e7f7cac",
+    "zh:2a04376b7fa84681bd2938973c7d0822c8c0f0656a4e7661a2f50ac4d852d4a3",
+    "zh:30d6cdf321aaba874934cbde505333d89d172d8d5ffcf40b6e66626c57bc6ab2",
+    "zh:364639ee19cf4cfaa65de84a2a71d32725d5b728b71dd88d01ccb639c006c1cf",
+    "zh:4e02252cd88b6f59f556f49c5ce46a358046c98f069230358ac15f4030ae1e76",
+    "zh:611717320f20b3512ceb90abddd5198a85e1093965ce59e3ef8183188c84f8c3",
+    "zh:630be3b9ba5b3a95ecb2ce2f3523714ab37cd8bcd7479c879a769e6a446ab5ed",
+    "zh:6701f9d3ae1ffadb3ebefbe75c9d82668cc5495b8f826e498adb8530e202b652",
+    "zh:6dc6fdfa7469c9de7b405c68b2f6a09a3438db1ef09d348e49c7ceff4300b01a",
+    "zh:84c8140d8af6965fa9cd80e52eb2ee3d273e3ab7762719a8d1af665c08fab748",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b6b4f7d4cea37ba7a42a47d506115498858bcd6440ad97dfb214c13a688ba90",
+    "zh:a7f876af20f5c5dae8e333ec0dfc901e26aa801137e7df65fb365565637bbfe2",
+    "zh:ad107b8e11dd0609b856584ce70ae6621aa4f1f946da51f7c792f1259e3f9c27",
+    "zh:d5dc1683693a5fe2652952f50dbbeccd02716799c26c6d1a1378b226cf845e9b",
   ]
 }
 

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -10,12 +10,30 @@ def lambda_handler(event, context):
     yesterday = today - timedelta(days=1)
 
     client = boto3.client("cloudtrail")
-    eds_id = event["eds-urn"].replace('"', "").split("/")[1]
+    eds_id = event["eds-arn"].replace('"', "").split("/")[1]
 
     query = (
-        "SELECT userIdentity.arn AS Name, userIdentity.type AS Type, eventName"
-        f" FROM {eds_id} WHERE eventTime > '{yesterday} 00:00:00'"
-        f" AND eventTime < '{today} 00:00:00'"
+        "SELECT userIdentity.arn AS Name, eventName "
+        f"FROM {eds_id} "
+        f"WHERE userIdentity.type='IAMUser' "
+        f"AND eventTime > '{yesterday} 00:00:00' "
+        f"AND eventTime < '{today} 00:00:00'"
     )
     response = client.start_query(QueryStatement=query)
-    print(response)
+    query_id = response["QueryId"]
+    while True:
+        response = client.get_query_results(
+            EventDataStore=eds_id, QueryId=query_id
+        )
+        if response["QueryStatus"] == "FINISHED":
+            break
+    client = boto3.client("dynamodb")
+    response = client.put_item(
+        TableName=f"{event['table']}",
+        Item={
+            "date": {"S": str(yesterday)},
+            "num": {
+                "S": str(response["QueryStatistics"]["TotalResultsCount"])
+            },
+        },
+    )


### PR DESCRIPTION
Using AWS DynamoDB service for tracking the number of "problematic" api calls per date